### PR TITLE
some trivial changes to Rule and Grammar classes

### DIFF
--- a/Parakeet/Grammar.cs
+++ b/Parakeet/Grammar.cs
@@ -16,7 +16,7 @@ namespace Ara3D.Parakeet
     {
         public abstract Rule StartRule { get; }
         public virtual Rule WS => BooleanRule.True;
-        public Dictionary<string, Rule> Lookup = new Dictionary<string, Rule>();
+        public readonly Dictionary<string, Rule> Lookup = new Dictionary<string, Rule>();
 
         public Rule GetRuleFromName(string name)
         {

--- a/Parakeet/Grammar.cs
+++ b/Parakeet/Grammar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -15,7 +15,7 @@ namespace Ara3D.Parakeet
     public abstract class Grammar : IGrammar
     {
         public abstract Rule StartRule { get; }
-        public virtual Rule WS { get; }
+        public virtual Rule WS => BooleanRule.True;
         public Dictionary<string, Rule> Lookup = new Dictionary<string, Rule>();
 
         public Rule GetRuleFromName(string name)

--- a/Parakeet/Grammar.cs
+++ b/Parakeet/Grammar.cs
@@ -43,6 +43,8 @@ namespace Ara3D.Parakeet
 
         public Rule Recursive(string inner)
             => new RecursiveRule(() => GetRuleFromName(inner));
+        public Rule Recursive(Func<Rule> func)
+            => new RecursiveRule(func);
 
         public Rule Named(Rule r, [CallerMemberName] string name = "")
         {

--- a/Parakeet/GrammarExtensions.cs
+++ b/Parakeet/GrammarExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -86,6 +86,8 @@ namespace Ara3D.Parakeet
                     return $"_END_";
                 case CharRule ch:
                     return $"'{ch.Char}'";
+                case BooleanRule br:
+                    return br.Value ? "_TRUE_" : "_FALSE_";
                 default:
                     return "_UNKNOWN_";
             }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -767,6 +767,9 @@ namespace Ara3D.Parakeet
     /// </summary>
     public class BooleanRule : Rule
     {
+        public static BooleanRule True { get; } = new BooleanRule(true);
+        public static BooleanRule False { get; } = new BooleanRule(false);
+
         public readonly bool Value;
 
         public BooleanRule(bool b)

--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -12,7 +12,8 @@ namespace Ara3D.Parakeet
 
         private readonly TextWriter Logger;
 
-        public RuleOptimizer(Grammar g, TextWriter logger = null)
+        public RuleOptimizer(Grammar g, TextWriter logger = null) :
+            this(logger)
         {
             foreach (var r in g.GetRules())
             {


### PR DESCRIPTION
1. add static True/False instances to `BooleanRule`
just for handiness...

2. make `Grammar.WS` returns `BooleanRule.True`
in some usage, for example `BaseCommonGrammar.Keyword(Rule)` or `BaseCommonGrammar.Sym(Rule)`, we do `Named(r + WS, ...)` which constructs a `SequenceRule` containing `null` which fails during runtime.
thus, make `WS => BooleanRule.True` to always match without advancing the `ParserState`.

3. make `Grammar.Lookup` readonly
reflects the concept - the lookup table shouldn't be changed, anyway.

4. handle `BooleanRule` in `GrammarExtensions.ToDefinition()`
so we actually print something instead of `"_UNKNOWN_"`

5. add a helper `Grammar.Recursive(Func<Rule>)`
this is probably faster than reflection-based name look-up, because we just know which rule it is.
however the rule is cached in `ReflectionRule`, anyway. so the speed-up might be really subtle.
for example, in `CombinatorCalculusGrammar`, do `public Rule Application => Node(Recursive(() => Term) + Recursive(() => Term);` instead of `public Rule Application => Node(Recursive(nameof(Term)) + Recursive(nameof(Term));`.

6. fix a NPE introduced in [#4fd04399b9576f709470ce9f560c8c5e6f203d0e](https://github.com/ara3d/parakeet/commit/4fd04399b9576f709470ce9f560c8c5e6f203d0e)
constructor calls should be chained.