### PR TITLE
use `string.IsNullOrEmpty(s)` to check the input pattern string

### DIFF
--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -191,7 +191,7 @@ namespace Ara3D.Parakeet
 
         public StringRule(string s)
         {
-            if (s.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(s))
                 throw new ArgumentException("Pattern must be non-empty", nameof(s));
             Pattern = s;
         }


### PR DESCRIPTION
`s.IsNullOrEmpty()` throws a NPE without the message.
use `string.IsNullOrEmpty(s)` to check for nullness and emptiness, so the next line of code gets to run.
