### PR TITLE
RFE: debugging ability

### DIFF
--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -449,15 +449,10 @@ namespace Ara3D.Parakeet
             {
                 curr = next;
                 next = Rule.Match(curr);
-#if DEBUG
-                if (next != null)
+                if (next != null && next.Position <= curr.Position)
                 {
-                    if (next.Position <= curr.Position)
-                    {
-                        throw new ParserException(curr, "Parser is no longer making progress");
-                    }
+                    throw new ParserException(curr, "Parser is no longer making progress");
                 }
-#endif
             }
             return curr;
         }
@@ -491,15 +486,10 @@ namespace Ara3D.Parakeet
             {
                 curr = next;
                 next = Rule.Match(curr);
-#if DEBUG
-                if (next != null)
+                if (next != null && next.Position <= curr.Position)
                 {
-                    if (next.Position <= curr.Position)
-                    {
-                        throw new ParserException(curr, "Parser is no longer making progress");
-                    }
+                    throw new ParserException(curr, "Parser is no longer making progress");
                 }
-#endif
             }
             return curr;
         }
@@ -543,17 +533,12 @@ namespace Ara3D.Parakeet
             while (curr != null && i++ < Max)
             {
                 var next = Rule.Match(curr);
-#if DEBUG
-                if (next != null)
-                {
-                    if (next.Position <= curr.Position)
-                    {
-                        throw new ParserException(curr, "Parser is no longer making progress");
-                    }
-                }
-#endif
                 if (next == null)
                     return curr;
+                if (next.Position <= curr.Position)
+                {
+                    throw new ParserException(curr, "Parser is no longer making progress");
+                }
                 curr = next;
             }
             return curr;

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -25,17 +25,15 @@ namespace Ara3D.Parakeet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ParserState Match(ParserState state)
         {
-#if DEBUG
             // Trace the parsing during debug builds.
-            if (state.Input.Debugging && this.HasName())
+            if (state.Input.Debugging && Debugger.IsAttached && this.HasName())
             {
-                Console.WriteLine($"Starting parse - {this.GetName()} {state}");
+                Debug.WriteLine($"Starting parse - {this.GetName()} {state}");
                 var r = MatchImplementation(state);
                 var result = r?.ToString() ?? "FAILED";
-                Console.WriteLine($"Finished parse - {this.GetName()} {state} - {result}");
+                Debug.WriteLine($"Finished parse - {this.GetName()} {state} - {result}");
                 return r;
             }
-#endif
             return MatchImplementation(state);
         }
 


### PR DESCRIPTION
1. currently it only checks "parser not advancing" in `ZeroOrMoreRule`, `OneOrMoreRule`, and `CountedRule` on a DEBUG build.
however, nuget packages are always build with RELEASE configuration, guarding these checks with `#if DEBUG` make it harder to diagnostic what's going on under the hood - the client code just hit an infinite loop.
thus, just throw the `ParserException` for RELEASE builds.

2. enable the ability to trace rule matching process in an RELEASE build
similar reason to the previous one, nuget packages are build with RELEASE configuration...

well, the assumption that "nuget packages are always RELEASE builds" might not be that correct.
they can be build in DEBUG, however packages on nuget.org are RELEASE, anyway.