### PR TITLE
let the `RuleOptimizer` optimize more rules

### DIFF
--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -337,6 +337,22 @@ namespace Ara3D.Parakeet
                         
                     return new ZeroOrMoreRule(inner);
                 }
+
+                case OneOrMoreRule oom:
+                {
+                    var inner = Optimize(oom.Rule);
+
+                    if (inner is OptionalRule opt)
+                        return Log(r, null, new ZeroOrMoreRule(opt.Rule), "A?+ => A*");
+
+                    if (inner is ZeroOrMoreRule z)
+                        return Log(r, null, new ZeroOrMoreRule(z.Rule), "A*? => A*");
+
+                    if (inner is OneOrMoreRule oom1)
+                        return Log(r, null, new CountedRule(oom1.Rule, 2, int.MaxValue), "A++ => A{2,}");
+
+                    return new OneOrMoreRule(inner);
+                }
             }
 
             return r;

--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -183,7 +183,7 @@ namespace Ara3D.Parakeet
                     return rr;
 
                 case NodeRule nodeRule:
-                    return nodeRule;
+                    return new NodeRule(Optimize(nodeRule.Rule), nodeRule.Name);
 
                 case NamedRule namedRule:
                     return Optimize(namedRule.Rule);

--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -337,6 +337,39 @@ namespace Ara3D.Parakeet
                         
                     return new ZeroOrMoreRule(inner);
                 }
+
+                case CountedRule counted:
+                {
+                    var inner = Optimize(counted.Rule);
+
+                    switch (counted.Min)
+                    {
+                        case 0:
+                            switch (counted.Max)
+                            {
+                                case 1:
+                                    return Log(r, null, new OptionalRule(inner), "A{0,1} => A?");
+
+                                case int.MaxValue:
+                                    return Log(r, null, new ZeroOrMoreRule(inner), "A{0,} => A*");
+                            }
+                            break;
+
+                        case 1:
+                            switch (counted.Max)
+                            {
+                                case 1:
+                                    return Log(r, null, inner, "A{1,1} => A");
+
+                                case int.MaxValue:
+                                    return Log(r, null, new OneOrMoreRule(inner), "A{1,} => A+");
+
+                            }
+                            break;
+                    }
+
+                    return new CountedRule(inner, counted.Min, counted.Max);
+                }
             }
 
             return r;

--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -117,7 +117,24 @@ namespace Ara3D.Parakeet
                         return Log(r1, r2, result, "a|b => [ab]");
                     }
                 }
-
+            }
+            {
+                if (r1 is BooleanRule br)
+                {
+                    if (br.Value)
+                        return Log(r1, r2, br, "_TRUE_|A => _TRUE_");
+                    else
+                        return Log(r1, r2, r2, "_FALSE_|A => A");
+                }
+            }
+            {
+                if (r2 is BooleanRule br)
+                {
+                    if (br.Value)
+                        return Log(r1, r2, br, "A|_TRUE_ => _TRUE_");
+                    else
+                        return Log(r1, r2, r1, "A|_FALSE_ => A");
+                }
             }
             return null;
         }
@@ -164,6 +181,27 @@ namespace Ara3D.Parakeet
                         return Log(r1, r2, r1.OneOrMore(), "A+A* => A+");
                 }
             }
+
+            {
+                if (r1 is BooleanRule br)
+                {
+                    if (br.Value)
+                        return Log(r1, r2, r2, "_TRUE_+A => A");
+                    else
+                        return Log(r1, r2, br, "_FALSE_+A => _FALSE_");
+                }
+            }
+
+            {
+                if (r2 is BooleanRule br)
+                {
+                    if (br.Value)
+                        return Log(r1, r2, r1, "A+_TRUE_ => A");
+                    else
+                        return Log(r1, r2, br, "A+_FALSE_ => _FALSE_");
+                }
+            }
+
             return null;
         }
 
@@ -203,6 +241,9 @@ namespace Ara3D.Parakeet
                     if (inner is NotAtRule notAt)
                         return Log(r, null, notAt.Rule, "&!A => !A");
 
+                    if (inner is BooleanRule br)
+                        return Log(r, null, inner, $"&{(br.Value ? "_TRUE_" : "_FALSE_")} => {(br.Value ? "_TRUE_" : "_FALSE_")}");
+
                     return new AtRule(inner);
                 }
 
@@ -215,6 +256,9 @@ namespace Ara3D.Parakeet
                     
                     if (inner is NotAtRule notAt2)
                         return Log(r, null, new AtRule(notAt2.Rule), "!!A => &A");
+
+                    if (inner is BooleanRule br)
+                        return Log(r, null, new BooleanRule(!br.Value), $"!{(br.Value ? "_TRUE_" : "_FALSE_")} => {(br.Value ? "_FALSE_" : "_TRUE_")}");
 
                     return new NotAtRule(inner);
                 }


### PR DESCRIPTION
1. optimize `RecursiveRule` **probably needs review**
the idea is to return a new `RecursiveRule` and fetch the optimized version of the original `Rule` on-demand.
the original rule is optimized (if not yet) when fetching `CachedRule`, so we have to add the newly instantiated `RecursiveRule` to the LUT first, or we run into infinite recursion...
this might have some memory overhead, since we reference the LUT, the whole `RuleOptimizer` instance cannot be garbage-collected.
we can probably combat this by discarding `RecursiveRule.RuleFunc` after `RecursiveRule.CachedRule` is resolved, thus the referenced `RuleOptimizer` get's a chance to be GC-ed.

2. optimize the inner `Rule` of `NodeRule`
don't just stop when seeing a `NodeRule`, else its body don't get optimized.

3. optimize `OneOrMoreRule`
just like `ZeroOrMoreRule`.
   - A?+ => A* // rule.Optional().OneOrMore() => rule.ZeroOrMore()
   - A*? => A* // rule.ZeroOrMore().OneOrMore() => rule.ZeroOrMore()
   - A++ => A{2,} // rule.OneOrMore().OneOrMore() => rule.Counted(2, int.MaxValue)

4. optimize `CountedRule`
just like `OneOrMoreRule` and `ZeroOrMoreRule`
   - A{0,0} => _FALSE_ // rule.Counted(0, 0) => false
   - A{0,1} => A? // rule.Counted(0, 1) => rule.Optional()
   - A{0,} => A* // rule.Counted(0, int.MaxValue) => rule.ZeroOrMore()
   - A{1,) => A+ // rule.Counted(1, int.MaxValue) => rule.OneOrMore()

5. optimize `BooleanRule` **probably needs review**
   1. AtRule:
       - &_TRUE_ => _TRUE_ // rule.At(true) => true
       - &_FALSE_ => _FALSE_ // rule.At(false) => false
   2. NotAtRule:
       - !_TRUE_ => _FALSE_ // true.Not() => false
       - !_FALSE_ => _TRUE_ // false.Not() => true
   3. SequenceRule:
       - _TRUE_+A => A // true + rule => rule
       - _FALSE_+A => _FALSE_ // false + rule => false
       - A+_TRUE_ => A // seq + true => rule
       - A+_FALSE_ => _FALSE_ // rule + false => false
   4. ChoiceRule:
       - _TRUE_|A => _TRUE_ // true | rule => true
       - _FALSE_|A => A // false | rule => rule
       - A|_TRUE_ => _TRUE_ // rule | true => true
       - A|_FALSE_ => A // rule | false => rule

with these optimizations, `JsonTests.CompareToNewtonsoft()` yields ~10% speed-ups on my machine.
DEBUG version of the test went from ~16s to ~14s.
this is probably mostly because the `NodeRule.Body()` are getting optimized, now.

I'll post the tests in another PR.
```
File size = 32706k
It took 00:00:01.2276041 to parse using Newtonsoft
It took 00:00:16.5802442 to parse using Parakeet
Inner tree nodes = 3265209
It took 00:00:00.0073892 to optimize the rule
It took 00:00:14.6678079 to parse optimized using Parakeet
Inner tree nodes = 3265209
```