### PR TITLE
[optimizer] don't merge `A+B|B => A?+B` for `ChoiceRule`

### DIFF
--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -290,7 +290,7 @@ namespace Ara3D.Parakeet
                     Debug.Assert(!list.Any(t => t is ChoiceRule));
 
                     if (list.Count == 1)
-                        return Log(r, null, list[0], "(A+_) => A");
+                        return Log(r, null, list[0], "(A|_) => A");
 
                     return new ChoiceRule(list.ToArray());
                 }

--- a/Parakeet/RuleOptimizer.cs
+++ b/Parakeet/RuleOptimizer.cs
@@ -71,10 +71,6 @@ namespace Ara3D.Parakeet
                     return Log(r1, r2, seq[0].Then(r2.Optional()), "A+B|A => A+B?");
             }
             {
-                if (r1 is SequenceRule seq && seq.Count == 2 && seq[1] == r2)
-                    return Log(r1, r2, seq[0].Optional().Then(r2), "A+B|B => A?+B");
-            }
-            {
                 if (r2 is SequenceRule seq && seq.Rules.Length > 1 && seq[0] == r1)
                     return Log(r1, r2, r1, "A|A+B => A");
             }


### PR DESCRIPTION
we actually can't do this.

for `A+B1|B2`:
   - when `A` matches, tries to match `B1`.
      - when `B1` matches, `A+B1` matches, and `A+B1|B2` matches.
      - when `B1` fails, `A+B1` fails, fallback to `B2`
          - when `B2` matches, `A+B1|B2` matches
          - when `B2` fails, `A+B1|B2` fails.
   - when `A` fails, try to match B2.
      - when `B2` matches, `A+B1|B2` matches
      - when `B2` fails, `A+B1|B2` fails.

however, for `A?+B`:
   - when `A` matches, tries to match `B`
      - when `B` matches, `A?+B` matches
      - when `B` fails, fail. (no fallback path to match `B` only)
   - when `A` fails, tries to match `B`
      - when `B` matches, `A?+B` matches
      - when `B` fails, fail.

the problem is for `A?+B`, when `A` matches, it wants to match a `B`, and success only when a valid `B` matches.
if `A` matches but `B` doesn't, `A?+B` fails.
this actually behaves different than `A+B|B`.
