### PR TITLE
rule equality and hash codes

### DIFF
--- a/Parakeet.Tests/RuleTests.cs
+++ b/Parakeet.Tests/RuleTests.cs
@@ -1,0 +1,87 @@
+﻿namespace Ara3D.Parakeet.Tests
+{
+    internal class TestGrammar : Grammar
+    {
+        public static TestGrammar Instance { get; } = new TestGrammar();
+        public override Rule StartRule => null;
+
+        public Rule ReferenceSelfByName => Node(Recursive(nameof(ReferenceSelfByName)));
+        public Rule ReferenceSelfByProperty => Node(Recursive(() => ReferenceSelfByProperty));
+    }
+
+    public static class RuleTests
+    {
+        private static Rule[] TestRules = new[] { new StringRule("test1"), new StringRule("test2"), };
+        private static Rule TestRuleProp => new StringRule(nameof(TestRuleProp));
+        private static Rule TestRuleFunc() => new StringRule(nameof(TestRuleFunc));
+        private static RecursiveRule GetRecursiveRuleLambda() => new RecursiveRule(() => TestRuleProp);
+        private static RecursiveRule GetRecursiveRuleMethod() => new RecursiveRule(() => TestRuleFunc());
+        private static RecursiveRule GetRecursiveRuleLambda(int n) => new RecursiveRule(() => TestRules[n]);
+
+        public static IEnumerable<(Rule, Rule, string)> RecursiveRuleEquals
+        {
+            get
+            {
+                var g1 = new TestGrammar();
+                var g2 = new TestGrammar();
+                var n = new NamedRule("test", "test");
+
+                yield return (new RecursiveRule(() => TestRuleProp), new RecursiveRule(() => TestRuleProp), "Lambda returning same rule");
+                yield return (new RecursiveRule(TestRuleFunc), new RecursiveRule(TestRuleFunc), "Referencing same method");
+                yield return (new RecursiveRule(() => n), new RecursiveRule(() => n), "Reference same lambda");
+                yield return (GetRecursiveRuleLambda(), GetRecursiveRuleLambda(), "Same method returns (Lambda)");
+                yield return (GetRecursiveRuleMethod(), GetRecursiveRuleMethod(), "Same method returns (Method)");
+                yield return (GetRecursiveRuleLambda(0), GetRecursiveRuleLambda(0), "Same method returns (Lambda with same parameters)");
+                yield return (GetRecursiveRuleLambda(), new RecursiveRule(() => TestRuleProp), "Different method but same lambda");
+                yield return (g1.ReferenceSelfByName, g1.ReferenceSelfByName, "Recursive rule referencing self (by name)");
+                yield return (g2.ReferenceSelfByProperty, g2.ReferenceSelfByProperty, "Recursive rule referencing self (by property)");
+            }
+        }
+
+        public static IEnumerable<(Rule, Rule, string)> RecursiveRuleNotEquals
+        {
+            get
+            {
+                var g1 = new TestGrammar();
+                var g2 = new TestGrammar();
+                var n1 = new NamedRule("test1", "test1");
+                var n2 = new NamedRule("test2", "test2");
+                yield return (new RecursiveRule(() => n1), new RecursiveRule(() => n2), "Different inner rules");
+                yield return (GetRecursiveRuleLambda(0), GetRecursiveRuleLambda(1), "Same method with different lambda parameters");
+                yield return (g1.ReferenceSelfByName, g2.ReferenceSelfByName, "Same rule from different grammar instance");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(RecursiveRuleEquals))]
+        public static void RecursiveRuleTest_Equals((Rule rr1, Rule rr2, string desc) input)
+        {
+            Console.WriteLine($"{input.desc}:");
+
+            var hash1 = input.rr1.GetHashCode();
+            var hash2 = input.rr2.GetHashCode();
+
+            Console.WriteLine($"  rr1 => 0x{hash1:X8}");
+            Console.WriteLine($"  rr2 => 0x{hash2:X8}");
+
+            Assert.AreEqual(hash1, hash2);
+            Assert.AreEqual(input.rr1, input.rr2);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(RecursiveRuleNotEquals))]
+        public static void RecursiveRuleTest_NotEquals((Rule rr1, Rule rr2, string desc) input)
+        {
+            Console.WriteLine($"{input.desc}:");
+
+            var hash1 = input.rr1.GetHashCode();
+            var hash2 = input.rr2.GetHashCode();
+
+            Console.WriteLine($"  rr1 => 0x{hash1:X8}");
+            Console.WriteLine($"  rr2 => 0x{hash2:X8}");
+
+            Assert.AreNotEqual(hash1, hash2);
+            Assert.AreNotEqual(input.rr1, input.rr2);
+        }
+    }
+}

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -405,7 +405,7 @@ namespace Ara3D.Parakeet
             => obj is EndOfInputRule;
         
         public override int GetHashCode() 
-            => nameof(EndOfInputRule).GetHashCode();
+            => Hash(typeof(EndOfInputRule));
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -693,7 +693,7 @@ namespace Ara3D.Parakeet
             => obj is AtRule at && Rule.Equals(at.Rule);
         
         public override int GetHashCode() 
-            => Hash(Rule);
+            => Hash(typeof(AtRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -426,7 +426,7 @@ namespace Ara3D.Parakeet
             => obj is NodeRule nr && Name == nr.Name && Rule.Equals(nr.Rule);
 
         public override int GetHashCode() 
-            => Hash(Rule, Name);
+            => Hash(typeof(NodeRule), Rule, Name);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -543,7 +543,7 @@ namespace Ara3D.Parakeet
         }
 
         public override bool Equals(object obj) 
-            => obj is CountedRule o && o.Rule.Equals(Rule);
+            => obj is CountedRule o && Min == o.Min && Max == o.Max && o.Rule.Equals(Rule);
         
         public override int GetHashCode() 
             => Hash(typeof(CountedRule), Min, Max, Rule);

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Ara3D.Utils;
 
+#pragma warning disable CS0659 // class overrides Object.Equals(object o), but not Object.GetHashCode()
+
 namespace Ara3D.Parakeet
 {
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -176,7 +176,7 @@ namespace Ara3D.Parakeet
             => obj is RecursiveRule other && other.RuleFunc == RuleFunc;
         
         public override int GetHashCode() 
-            => Hash(RuleFunc);
+            => Hash(typeof(RecursiveRule), RuleFunc);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -386,7 +386,7 @@ namespace Ara3D.Parakeet
             => obj is CharRule csr && Char == csr.Char;
 
         public override int GetHashCode() 
-            => Hash(Char);
+            => Hash(typeof(CharRule), Char);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -201,7 +201,7 @@ namespace Ara3D.Parakeet
             => obj is StringRule smr && smr.Pattern == Pattern;
         
         public override int GetHashCode() 
-            => Hash(Pattern);
+            => Hash(typeof(StringRule), Pattern);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -22,6 +22,10 @@ namespace Ara3D.Parakeet
         /// </summary>
         protected abstract ParserState MatchImplementation(ParserState state);
 
+        protected virtual int GetHashCodeInternal() => throw new NotImplementedException();
+
+        public Rule() => LazyHashCode = new Lazy<int>(GetHashCodeInternal);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ParserState Match(ParserState state)
         {
@@ -108,10 +112,10 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj)
             => throw new NotImplementedException();
 
-        public override int GetHashCode()
-            => throw new NotImplementedException();
+        private readonly Lazy<int> LazyHashCode;
+        public override sealed int GetHashCode() => LazyHashCode.Value;
 
-        public virtual IReadOnlyList<Rule> Children 
+        public virtual IReadOnlyList<Rule> Children
             => Array.Empty<Rule>();
 
         public override string ToString()
@@ -137,7 +141,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is NamedRule other && other.Rule.Equals(Rule) && Name == other.Name;
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(NamedRule), Rule, Name);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -208,7 +212,7 @@ namespace Ara3D.Parakeet
             return true;
         }
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal() 
         {
             if (RuleFunc.Target is null)
             {
@@ -250,7 +254,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is StringRule smr && smr.Pattern == Pattern;
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(StringRule), Pattern);
     }
 
@@ -275,7 +279,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj)
             => obj is CaseInvariantStringRule smr && smr.Pattern == Pattern;
 
-        public override int GetHashCode()
+        protected override int GetHashCodeInternal()
             => Hash(typeof(CaseInvariantStringRule), Pattern);
     }
 
@@ -293,7 +297,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is AnyCharRule;
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(AnyCharRule));
     }
 
@@ -315,7 +319,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj)
             => obj is CharRangeRule crr && crr.From == From && crr.To == To;
 
-        public override int GetHashCode()
+        protected override int GetHashCodeInternal()
             => Hash(From, To);
     }
 
@@ -341,23 +345,23 @@ namespace Ara3D.Parakeet
 
         public readonly bool[] Chars;
 
-        public CharSetRule(params char[] chars) 
-            : this(CharsToTable(chars)) 
+        public CharSetRule(params char[] chars)
+            : this(CharsToTable(chars))
         { }
 
-        public CharSetRule(bool[] chars) 
+        public CharSetRule(bool[] chars)
             => Chars = chars;
 
         protected override ParserState MatchImplementation(ParserState state)
-            => state.AtEnd() ? null 
-                : state.GetCurrent() < 128 && Chars[state.GetCurrent()] 
-                    ? state.Advance() 
+            => state.AtEnd() ? null
+                : state.GetCurrent() < 128 && Chars[state.GetCurrent()]
+                    ? state.Advance()
                     : null;
 
-        public override bool Equals(object obj) 
+        public override bool Equals(object obj)
             => obj is CharSetRule csr && Chars.SequenceEqual(csr.Chars);
 
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(CharSetRule), Hash(Chars.Cast<object>().ToArray()));
 
         public CharSetRule Union(CharSetRule other)
@@ -435,7 +439,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is CharRule csr && Char == csr.Char;
 
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(CharRule), Char);
     }
 
@@ -454,7 +458,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is EndOfInputRule;
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(EndOfInputRule));
     }
 
@@ -475,7 +479,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is NodeRule nr && Name == nr.Name && Rule.Equals(nr.Rule);
 
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(NodeRule), Rule, Name);
     }
 
@@ -508,7 +512,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is ZeroOrMoreRule z && z.Rule.Equals(Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(ZeroOrMoreRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -545,7 +549,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is OneOrMoreRule o && o.Rule.Equals(Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(OneOrMoreRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -595,7 +599,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is CountedRule o && Min == o.Min && Max == o.Max && o.Rule.Equals(Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(CountedRule), Min, Max, Rule);
 
         public override IReadOnlyList<Rule> Children 
@@ -620,7 +624,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is OptionalRule opt && opt.Rule.Equals(Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(OptionalRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -682,7 +686,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is SequenceRule seq && Rules.SequenceEqual(seq.Rules);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(SequenceRule), Hash(Rules));
 
         public override IReadOnlyList<Rule> Children => Rules;
@@ -719,7 +723,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is ChoiceRule ch && Rules.SequenceEqual(ch.Rules);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(ChoiceRule), Hash(Rules));
 
         public override IReadOnlyList<Rule> Children => Rules;
@@ -742,7 +746,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is AtRule at && Rule.Equals(at.Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(AtRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -765,7 +769,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is NotAtRule notAt && Rule.Equals(notAt.Rule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(NotAtRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
@@ -790,7 +794,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj) 
             => obj is OnFail rec && RecoveryRule.Equals(rec.RecoveryRule);
         
-        public override int GetHashCode() 
+        protected override int GetHashCodeInternal()
             => Hash(typeof(OnFail), RecoveryRule);
     }
 
@@ -814,7 +818,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj)
             => obj is BooleanRule br && br.Value == Value;
 
-        public override int GetHashCode()
+        protected override int GetHashCodeInternal()
             => Hash(typeof(BooleanRule), Value);
     }
 }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -226,7 +226,7 @@ namespace Ara3D.Parakeet
             => obj is CaseInvariantStringRule smr && smr.Pattern == Pattern;
 
         public override int GetHashCode()
-            => Hash(Pattern);
+            => Hash(typeof(CaseInvariantStringRule), Pattern);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -741,7 +741,7 @@ namespace Ara3D.Parakeet
             => obj is OnFail rec && RecoveryRule.Equals(rec.RecoveryRule);
         
         public override int GetHashCode() 
-            => Hash(RecoveryRule);
+            => Hash(typeof(OnFail), RecoveryRule);
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -571,7 +571,7 @@ namespace Ara3D.Parakeet
             => obj is OptionalRule opt && opt.Rule.Equals(Rule);
         
         public override int GetHashCode() 
-            => Hash(Rule);
+            => Hash(typeof(OptionalRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -716,7 +716,7 @@ namespace Ara3D.Parakeet
             => obj is NotAtRule notAt && Rule.Equals(notAt.Rule);
         
         public override int GetHashCode() 
-            => Hash(Rule);
+            => Hash(typeof(NotAtRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -308,7 +308,7 @@ namespace Ara3D.Parakeet
             => obj is CharSetRule csr && Chars.SequenceEqual(csr.Chars);
 
         public override int GetHashCode() 
-            => Hash(nameof(CharSetRule));
+            => Hash(typeof(CharSetRule));
 
         public CharSetRule Union(CharSetRule other)
         {

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -633,7 +633,7 @@ namespace Ara3D.Parakeet
             => obj is SequenceRule seq && Rules.SequenceEqual(seq.Rules);
         
         public override int GetHashCode() 
-            => Hash(Rules);
+            => Hash(typeof(SequenceRule), Hash(Rules));
 
         public override IReadOnlyList<Rule> Children => Rules;
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -765,6 +765,6 @@ namespace Ara3D.Parakeet
             => obj is BooleanRule br && br.Value == Value;
 
         public override int GetHashCode()
-            => Hash(Value);
+            => Hash(typeof(BooleanRule), Value);
     }
 }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -244,7 +244,7 @@ namespace Ara3D.Parakeet
             => obj is AnyCharRule;
         
         public override int GetHashCode() 
-            => nameof(AnyCharRule).GetHashCode();
+            => Hash(typeof(AnyCharRule));
     }
 
     /// <summary>

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -141,7 +141,7 @@ namespace Ara3D.Parakeet
             => Rule.Match(state);
         
         public override bool Equals(object obj) 
-            => obj is NamedRule other && other.Rule.Equals(Rule) && Name == other.Name;
+            => obj is NamedRule other && Equals(other.GetType(), typeof(NamedRule)) && other.Rule.Equals(Rule) && Name == other.Name;
         
         protected override int GetHashCodeInternal()
             => Hash(typeof(NamedRule), Rule, Name);

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -308,7 +308,7 @@ namespace Ara3D.Parakeet
             => obj is CharSetRule csr && Chars.SequenceEqual(csr.Chars);
 
         public override int GetHashCode() 
-            => Hash(typeof(CharSetRule), Hash(Chars));
+            => Hash(typeof(CharSetRule), Hash(Chars.Cast<object>().ToArray()));
 
         public CharSetRule Union(CharSetRule other)
         {

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -670,7 +670,7 @@ namespace Ara3D.Parakeet
             => obj is ChoiceRule ch && Rules.SequenceEqual(ch.Rules);
         
         public override int GetHashCode() 
-            => Hash(Rules);
+            => Hash(typeof(ChoiceRule), Hash(Rules));
 
         public override IReadOnlyList<Rule> Children => Rules;
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -138,7 +138,7 @@ namespace Ara3D.Parakeet
             => obj is NamedRule other && other.Rule.Equals(Rule) && Name == other.Name;
         
         public override int GetHashCode() 
-            => Hash(Rule, Name);
+            => Hash(typeof(NamedRule), Rule, Name);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -177,18 +177,22 @@ namespace Ara3D.Parakeet
             if (!(obj is RecursiveRule other))
                 return false;
 
-            // compare the delegate Method's IL code  
-            var il1 = RuleFunc.Method.GetMethodBody().GetILAsByteArray();
-            var il2 = other.RuleFunc.Method.GetMethodBody().GetILAsByteArray();
-            if (!il1.SequenceEqual(il2))
-                return false;
-
-            // compare by delegate Target reference  
-            if (ReferenceEquals(RuleFunc.Target, other.RuleFunc.Target))
+            // compare by delegate Method and Target reference
+            if (ReferenceEquals(RuleFunc.Method, other.RuleFunc.Method) 
+                && ReferenceEquals(RuleFunc.Target, other.RuleFunc.Target))
                 return true;
 
             // compare by delegate Target type  
             if (!Equals(RuleFunc.Target.GetType(), other.RuleFunc.Target.GetType()))
+                return false;
+
+            // at this point, all fast-path failed, we have to compare the
+            // delegate Method's IL code and Target's content.
+
+            // compare the delegate Method's IL code  
+            var il1 = RuleFunc.Method.GetMethodBody().GetILAsByteArray();
+            var il2 = other.RuleFunc.Method.GetMethodBody().GetILAsByteArray();
+            if (!il1.SequenceEqual(il2))
                 return false;
 
             // compare the delegate Target content  

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -308,7 +308,7 @@ namespace Ara3D.Parakeet
             => obj is CharSetRule csr && Chars.SequenceEqual(csr.Chars);
 
         public override int GetHashCode() 
-            => Hash(typeof(CharSetRule));
+            => Hash(typeof(CharSetRule), Hash(Chars));
 
         public CharSetRule Union(CharSetRule other)
         {

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -114,6 +114,7 @@ namespace Ara3D.Parakeet
         public override bool Equals(object obj)
             => throw new NotImplementedException();
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly Lazy<int> LazyHashCode;
         public override sealed int GetHashCode() => LazyHashCode.Value;
 
@@ -137,7 +138,7 @@ namespace Ara3D.Parakeet
         public NamedRule(Rule r, string name) 
             => (Rule, Name) = (r, name);
         
-        protected override ParserState MatchImplementation(ParserState state) 
+        protected override ParserState MatchImplementation(ParserState state)
             => Rule.Match(state);
         
         public override bool Equals(object obj) 
@@ -471,14 +472,14 @@ namespace Ara3D.Parakeet
     /// </summary>
     public class NodeRule : NamedRule
     {
-        public NodeRule(Rule rule, string name) 
+        public NodeRule(Rule rule, string name)
             : base(rule, name)
         { }
 
         protected override ParserState MatchImplementation(ParserState state)
             => Rule.Match(state.AddNode(Name, null))?.AddNode(Name, state);
 
-        public override bool Equals(object obj) 
+        public override bool Equals(object obj)
             => obj is NodeRule nr && Name == nr.Name && Rule.Equals(nr.Rule);
 
         protected override int GetHashCodeInternal()
@@ -568,7 +569,7 @@ namespace Ara3D.Parakeet
         public readonly int Max;
         public readonly Rule Rule;
 
-        public CountedRule(Rule rule, int min, int max) 
+        public CountedRule(Rule rule, int min, int max)
             => (Rule, Min, Max) = (rule, min, max);
 
         protected override ParserState MatchImplementation(ParserState state)

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -546,7 +546,7 @@ namespace Ara3D.Parakeet
             => obj is CountedRule o && o.Rule.Equals(Rule);
         
         public override int GetHashCode() 
-            => Hash(Rule);
+            => Hash(typeof(CountedRule), Min, Max, Rule);
 
         public override IReadOnlyList<Rule> Children 
             => new[] { Rule };

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -459,7 +459,7 @@ namespace Ara3D.Parakeet
             => obj is ZeroOrMoreRule z && z.Rule.Equals(Rule);
         
         public override int GetHashCode() 
-            => Hash (Rule);
+            => Hash(typeof(ZeroOrMoreRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }

--- a/Parakeet/Rule.cs
+++ b/Parakeet/Rule.cs
@@ -496,7 +496,7 @@ namespace Ara3D.Parakeet
             => obj is OneOrMoreRule o && o.Rule.Equals(Rule);
         
         public override int GetHashCode() 
-            => Hash(Rule);
+            => Hash(typeof(OneOrMoreRule), Rule);
 
         public override IReadOnlyList<Rule> Children => new[] { Rule };
     }


### PR DESCRIPTION
- also hash the `Type` for various rule classes
   - `BooleanRule`
   - `OnFail`
   - `AtRule`
   - `NotAtRule`
   - `SequenceRule` (wasn't able to distinguish between a `SequenceRule` and a `ChoiceRule` with same inner `Rule`s by hash)
   - `ChoiceRule` (wasn't able to distinguish between a `SequenceRule` and a `ChoiceRule` with same inner `Rule`s by hash)
   - `NamedRule` (wasn't able to distinguish between a `NamedRule` and a `NodeRule` with same inner `Rule` by hash)
   - `NodeRule` (wasn't able to distinguish between a `NamedRule` and a `NodeRule` with same inner `Rule` by hash)
   - `StringRule` (wasn't able to distinguish between a `StringRule` and `CaseInvariantStringRule` with same `Pattern` by hash)
   - `CaseInvariantStringRule` (wasn't able to distinguish between a `StringRule` and `CaseInvariantStringRule` with same `Pattern` by hash)
   - `CharRule`
- hash against the `Type` instead of name
   - `AnyCharRule`
   - `EndOfInputRule`
   - `CharSetRule`
- hash the charset for `CharSetRule` (wasn't able to distinguish between two `CharSetRule`s with different charset)
- add `Type` to the hash for `CountedRule` and its variants (wasn't able to distinguish between these types with same inner `Rule`s by hash)
   - `ZeroOrMoreRule`
   - `OneOrMoreRule`
   - `OptionalRule`
   - `CountedRule`
- hash `Min` and `Max` for `CountedRule` (wasn't able to distinguish between two `CountedRule` with different `Min` and/or `Max` but same inner `Rule`s by hash)
- rework `GetHashCode()` and `Equals()` for `RecursiveRule`
   - now it works pretty well as expected, see the tests for more information.